### PR TITLE
Update whole schema

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -92,6 +92,29 @@ export const discordWebhookRelations = relations(discordWebhook, ({ one }) => ({
   }),
 }));
 
+export const slack = pgTable("slack", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+
+  appId: text("appId"),
+  authedUserId: text("authedUserId"),
+  authedUserToken: text("authedUserToken").unique(),
+  slackAccessToken: text("slackAccessToken").unique(),
+  botUserId: text("botUserId"),
+  teamId: text("teamId"),
+  teamName: text("teamName"),
+
+  userId: text("userId"),
+});
+
+export const slackRealtions = relations(slack, ({ one }) => ({
+  user: one(users, {
+    fields: [slack.userId],
+    references: [users.id],
+  }),
+}));
+
 export const accounts = pgTable(
   "account",
   {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -167,6 +167,35 @@ export const connectionsRelations = relations(connections, ({ one }) => ({
   }),
 }));
 
+export const workflows = pgTable("workflows", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+
+  nodes: text("nodes"),
+  edges: text("edges"),
+  name: text("name").notNull(),
+  discordTemplate: text("discordTemplate"),
+  notionTemplate: text("notionTemplate"),
+  notionAccessToken: text("notionAccessToken"),
+  notionDId: text("notionDId"),
+  slackTemplate: text("slackTemplate"),
+  slackChannels: text("slackChannels"),
+  slackAccessToken: text("slackAccessToken"),
+  flowPath: text("flowPath"),
+  cronPath: text("cronPath"),
+  publish: boolean("publish").default(false),
+  description: text("description").notNull(),
+  userId: text("userId"),
+});
+
+export const workflowsRelations = relations(workflows, ({ one }) => ({
+  user: one(users, {
+    fields: [workflows.userId],
+    references: [users.id],
+  }),
+}));
+
 export const accounts = pgTable(
   "account",
   {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -38,6 +38,18 @@ export const users = pgTable("user", {
   googleResourceId: text("googleResourceId").unique(),
 });
 
+export const usersRelations = relations(users, ({ one, many }) => ({
+  localGoogleCredential: one(localGoogleCredential, {
+    fields: [users.id],
+    references: [localGoogleCredential.userId],
+  }),
+  discordWebhook: many(discordWebhook),
+  notion: many(notion),
+  slack: many(slack),
+  connections: many(connections),
+  workflows: many(workflows),
+}));
+
 export const localGoogleCredential = pgTable("localGoogleCredential", {
   id: text("id")
     .primaryKey()

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -42,7 +42,7 @@ export const localGoogleCredential = pgTable("localGoogleCredential", {
   id: text("id")
     .primaryKey()
     .$defaultFn(() => crypto.randomUUID()),
-  accessToken: text("accessToken").unique(),
+  webhookId: text("webhookId").unique(),
 
   folderId: text("folderId"),
   pageToken: text("pageToken"),
@@ -71,6 +71,26 @@ export const localGoogleCredentialRelations = relations(
     }),
   })
 );
+
+export const discordWebhook = pgTable("discordWebhook", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  webhookId: text("webhookId").unique(),
+  url: text("url").unique(),
+  name: text("name"),
+  guildName: text("guildName"),
+  guildId: text("guildId"),
+  channelId: text("channelId").unique(),
+  userId: text("userId"),
+});
+
+export const discordWebhookRelations = relations(discordWebhook, ({ one }) => ({
+  user: one(users, {
+    fields: [discordWebhook.userId],
+    references: [users.id],
+  }),
+}));
 
 export const accounts = pgTable(
   "account",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -125,12 +125,44 @@ export const notion = pgTable("notion", {
   databaseId: text("databaseId").unique(),
   workspaceName: text("workspaceName"),
   workspaceIcon: text("workspaceIcon"),
-  userId: text("userId")
+  userId: text("userId"),
 });
 
-export const notionRealtions = relations(notion, ({ one }) => ({
+export const notionRealtions = relations(notion, ({ one, many }) => ({
   user: one(users, {
     fields: [notion.userId],
+    references: [users.id],
+  }),
+  connections: many(connections),
+}));
+
+export const connections = pgTable("connections", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+
+  type: text("type").unique(),
+  discordWebhookId: text("discordWebhookId"),
+  notionId: text("notionId"),
+  slackId: text("slackId"),
+  userId: text("userId"),
+});
+
+export const connectionsRelations = relations(connections, ({ one }) => ({
+  discordWebhook: one(discordWebhook, {
+    fields: [connections.discordWebhookId],
+    references: [discordWebhook.id],
+  }),
+  notion: one(notion, {
+    fields: [connections.notionId],
+    references: [notion.id],
+  }),
+  slack: one(slack, {
+    fields: [connections.slackId],
+    references: [slack.id],
+  }),
+  user: one(users, {
+    fields: [connections.userId],
     references: [users.id],
   }),
 }));

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -115,6 +115,26 @@ export const slackRealtions = relations(slack, ({ one }) => ({
   }),
 }));
 
+export const notion = pgTable("notion", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+
+  accessToken: text("accessToken").unique(),
+  workspaceId: text("workspaceId").unique(),
+  databaseId: text("databaseId").unique(),
+  workspaceName: text("workspaceName"),
+  workspaceIcon: text("workspaceIcon"),
+  userId: text("userId")
+});
+
+export const notionRealtions = relations(notion, ({ one }) => ({
+  user: one(users, {
+    fields: [notion.userId],
+    references: [users.id],
+  }),
+}));
+
 export const accounts = pgTable(
   "account",
   {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -23,6 +23,15 @@ export const users = pgTable("user", {
   email: text("email").unique(),
   emailVerified: timestamp("emailVerified", { mode: "date" }),
   image: text("image"),
+  tier: text("tier").default("Free"),
+  credits: text("credits").default("10"),
+
+  createdAt: timestamp("createdAt", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp(),
+  localGoogleId: text("localGoogleId").unique(),
+  googleResourceId: text("googleResourceId").unique(),
 });
 
 export const accounts = pgTable(


### PR DESCRIPTION
This pull request introduces several significant changes to the database schema in `src/db/schema.ts`. The changes include adding new fields to the `users` table, creating new tables for various integrations (e.g., Google, Discord, Slack, Notion), and defining relations between these tables.

### Schema Enhancements:

* Added new fields to the `users` table, including `tier`, `credits`, `createdAt`, `updatedAt`, `localGoogleId`, and `googleResourceId`.
* Created new tables for `localGoogleCredential`, `discordWebhook`, `slack`, `notion`, `connections`, and `workflows`, each with its own set of fields and primary keys.

### Relations Definition:

* Defined relations for the `users` table with `localGoogleCredential`, `discordWebhook`, `notion`, `slack`, `connections`, and `workflows` tables.
* Established relations for each new table (e.g., `localGoogleCredentialRelations`, `discordWebhookRelations`, `slackRealtions`, `notionRealtions`, `connectionsRelations`, `workflowsRelations`) to link them with the `users` table and other relevant tables.

### Configuration Changes:

* Replaced the hardcoded database connection string with an environment variable for better security and flexibility.