### PR TITLE
ADD: Schema migrations

### DIFF
--- a/drizzle/0002_noisy_venom.sql
+++ b/drizzle/0002_noisy_venom.sql
@@ -1,0 +1,92 @@
+CREATE TABLE "connections" (
+	"id" text PRIMARY KEY NOT NULL,
+	"type" text,
+	"discordWebhookId" text,
+	"notionId" text,
+	"slackId" text,
+	"userId" text,
+	CONSTRAINT "connections_type_unique" UNIQUE("type")
+);
+--> statement-breakpoint
+CREATE TABLE "discordWebhook" (
+	"id" text PRIMARY KEY NOT NULL,
+	"webhookId" text,
+	"url" text,
+	"name" text,
+	"guildName" text,
+	"guildId" text,
+	"channelId" text,
+	"userId" text,
+	CONSTRAINT "discordWebhook_webhookId_unique" UNIQUE("webhookId"),
+	CONSTRAINT "discordWebhook_url_unique" UNIQUE("url"),
+	CONSTRAINT "discordWebhook_channelId_unique" UNIQUE("channelId")
+);
+--> statement-breakpoint
+CREATE TABLE "localGoogleCredential" (
+	"id" text PRIMARY KEY NOT NULL,
+	"webhookId" text,
+	"folderId" text,
+	"pageToken" text,
+	"channelId" text,
+	"subscribed" boolean DEFAULT false,
+	"createdAt" timestamp with time zone DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL,
+	"userId" text,
+	CONSTRAINT "localGoogleCredential_webhookId_unique" UNIQUE("webhookId"),
+	CONSTRAINT "localGoogleCredential_channelId_unique" UNIQUE("channelId")
+);
+--> statement-breakpoint
+CREATE TABLE "notion" (
+	"id" text PRIMARY KEY NOT NULL,
+	"accessToken" text,
+	"workspaceId" text,
+	"databaseId" text,
+	"workspaceName" text,
+	"workspaceIcon" text,
+	"userId" text,
+	CONSTRAINT "notion_accessToken_unique" UNIQUE("accessToken"),
+	CONSTRAINT "notion_workspaceId_unique" UNIQUE("workspaceId"),
+	CONSTRAINT "notion_databaseId_unique" UNIQUE("databaseId")
+);
+--> statement-breakpoint
+CREATE TABLE "slack" (
+	"id" text PRIMARY KEY NOT NULL,
+	"appId" text,
+	"authedUserId" text,
+	"authedUserToken" text,
+	"slackAccessToken" text,
+	"botUserId" text,
+	"teamId" text,
+	"teamName" text,
+	"userId" text,
+	CONSTRAINT "slack_authedUserToken_unique" UNIQUE("authedUserToken"),
+	CONSTRAINT "slack_slackAccessToken_unique" UNIQUE("slackAccessToken")
+);
+--> statement-breakpoint
+CREATE TABLE "workflows" (
+	"id" text PRIMARY KEY NOT NULL,
+	"nodes" text,
+	"edges" text,
+	"name" text NOT NULL,
+	"discordTemplate" text,
+	"notionTemplate" text,
+	"notionAccessToken" text,
+	"notionDId" text,
+	"slackTemplate" text,
+	"slackChannels" text,
+	"slackAccessToken" text,
+	"flowPath" text,
+	"cronPath" text,
+	"publish" boolean DEFAULT false,
+	"description" text NOT NULL,
+	"userId" text
+);
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "tier" text DEFAULT 'Free';--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "credits" text DEFAULT '10';--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "createdAt" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "updatedAt" timestamp DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "localGoogleId" text;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "googleResourceId" text;--> statement-breakpoint
+ALTER TABLE "user" ADD CONSTRAINT "user_localGoogleId_unique" UNIQUE("localGoogleId");--> statement-breakpoint
+ALTER TABLE "user" ADD CONSTRAINT "user_googleResourceId_unique" UNIQUE("googleResourceId");

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,894 @@
+{
+  "id": "64a4f5c7-9def-447c-a5d8-288c47b3fb0b",
+  "prevId": "663ce73e-0998-4a3c-949a-1c1fcaf73dee",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_providerAccountId_pk": {
+          "name": "account_provider_providerAccountId_pk",
+          "columns": [
+            "provider",
+            "providerAccountId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticator": {
+      "name": "authenticator",
+      "schema": "",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticator_userId_user_id_fk": {
+          "name": "authenticator_userId_user_id_fk",
+          "tableFrom": "authenticator",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authenticator_userId_credentialID_pk": {
+          "name": "authenticator_userId_credentialID_pk",
+          "columns": [
+            "userId",
+            "credentialID"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "authenticator_credentialID_unique": {
+          "name": "authenticator_credentialID_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credentialID"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discordWebhookId": {
+          "name": "discordWebhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notionId": {
+          "name": "notionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slackId": {
+          "name": "slackId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_type_unique": {
+          "name": "connections_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discordWebhook": {
+      "name": "discordWebhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhookId": {
+          "name": "webhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guildName": {
+          "name": "guildName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guildId": {
+          "name": "guildId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channelId": {
+          "name": "channelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discordWebhook_webhookId_unique": {
+          "name": "discordWebhook_webhookId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhookId"
+          ]
+        },
+        "discordWebhook_url_unique": {
+          "name": "discordWebhook_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        },
+        "discordWebhook_channelId_unique": {
+          "name": "discordWebhook_channelId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "channelId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.localGoogleCredential": {
+      "name": "localGoogleCredential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhookId": {
+          "name": "webhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageToken": {
+          "name": "pageToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channelId": {
+          "name": "channelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribed": {
+          "name": "subscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "localGoogleCredential_webhookId_unique": {
+          "name": "localGoogleCredential_webhookId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhookId"
+          ]
+        },
+        "localGoogleCredential_channelId_unique": {
+          "name": "localGoogleCredential_channelId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "channelId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notion": {
+      "name": "notion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "databaseId": {
+          "name": "databaseId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspaceName": {
+          "name": "workspaceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspaceIcon": {
+          "name": "workspaceIcon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notion_accessToken_unique": {
+          "name": "notion_accessToken_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "accessToken"
+          ]
+        },
+        "notion_workspaceId_unique": {
+          "name": "notion_workspaceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspaceId"
+          ]
+        },
+        "notion_databaseId_unique": {
+          "name": "notion_databaseId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "databaseId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack": {
+      "name": "slack",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "appId": {
+          "name": "appId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authedUserId": {
+          "name": "authedUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authedUserToken": {
+          "name": "authedUserToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slackAccessToken": {
+          "name": "slackAccessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "botUserId": {
+          "name": "botUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teamName": {
+          "name": "teamName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_authedUserToken_unique": {
+          "name": "slack_authedUserToken_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "authedUserToken"
+          ]
+        },
+        "slack_slackAccessToken_unique": {
+          "name": "slack_slackAccessToken_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slackAccessToken"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Free'"
+        },
+        "credits": {
+          "name": "credits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'10'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "localGoogleId": {
+          "name": "localGoogleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleResourceId": {
+          "name": "googleResourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_localGoogleId_unique": {
+          "name": "user_localGoogleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "localGoogleId"
+          ]
+        },
+        "user_googleResourceId_unique": {
+          "name": "user_googleResourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "googleResourceId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verificationToken_identifier_token_pk": {
+          "name": "verificationToken_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nodes": {
+          "name": "nodes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edges": {
+          "name": "edges",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discordTemplate": {
+          "name": "discordTemplate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notionTemplate": {
+          "name": "notionTemplate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notionAccessToken": {
+          "name": "notionAccessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notionDId": {
+          "name": "notionDId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slackTemplate": {
+          "name": "slackTemplate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slackChannels": {
+          "name": "slackChannels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slackAccessToken": {
+          "name": "slackAccessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flowPath": {
+          "name": "flowPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cronPath": {
+          "name": "cronPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish": {
+          "name": "publish",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1734589279470,
       "tag": "0001_fantastic_mister_fear",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1734602820590,
+      "tag": "0002_noisy_venom",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
This pull request introduces several new database tables and modifies the existing `user` table to include additional columns. Additionally, it updates the metadata journal to reflect these changes.

Schema changes:

* [`drizzle/0002_noisy_venom.sql`](diffhunk://#diff-21a035d465aab4537c757ca47b2df6c242c68c4996cea9622506c0621c34bb8fR1-R92): Created new tables `connections`, `discordWebhook`, `localGoogleCredential`, `notion`, `slack`, and `workflows` with various constraints and columns.
* [`drizzle/0002_noisy_venom.sql`](diffhunk://#diff-21a035d465aab4537c757ca47b2df6c242c68c4996cea9622506c0621c34bb8fR1-R92): Modified the `user` table to add new columns `tier`, `credits`, `createdAt`, `updatedAt`, `localGoogleId`, and `googleResourceId`, along with unique constraints for `localGoogleId` and `googleResourceId`.

Metadata updates:

* [`drizzle/meta/_journal.json`](diffhunk://#diff-349e2e5efe6c282645244197ec3a36bee4f6fbc9988ee5acc46a05603f6829cdR18-R24): Updated the journal to include a new entry for the changes tagged as `0002_noisy_venom`.