### PR TITLE
ADD: minio object service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   minio:
     image: quay.io/minio/minio:RELEASE.2022-02-18T01-50-10Z
     volumes:
-      - ./data:/data
+      - minio:/data
     ports:
       - 9000:9000
       - 9001:9001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,21 @@ services:
     volumes:
       - postgres:/data/postgres
 
+  minio:
+    image: quay.io/minio/minio:RELEASE.2022-02-18T01-50-10Z
+    volumes:
+      - ./data:/data
+    ports:
+      - 9000:9000
+      - 9001:9001
+    environment:
+      MINIO_ROOT_USER: harshal
+      MINIO_ROOT_PASSWORD: 123456789
+      MINIO_ADDRESS: :9000
+      MINIO_CONSOLE_ADDRESS: :9001
+    command: server --console-address ":9001" /data
+    restart: always
+
 volumes:
   postgres:
+  minio:


### PR DESCRIPTION
This pull request includes a significant addition to the `docker-compose.yml` file, introducing a new service for MinIO. The changes primarily focus on setting up MinIO with the necessary configurations.

New service addition:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R15-R32): Added a new service for MinIO with the specified image, volumes, ports, environment variables, and command configurations.