### PR TITLE
ADD: Profile Picture & default values for user setting form

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,15 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+        search: "",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(main)/(pages)/settings/page.tsx
+++ b/src/app/(main)/(pages)/settings/page.tsx
@@ -1,7 +1,16 @@
 import ProfileForm from "@/components/forms/ProfileForm";
+import ProfilePicture from "@/components/ProfilePicture";
 import React from "react";
+import { auth } from "../../../../../auth";
+import { redirect } from "next/navigation";
 
-const Settings = () => {
+const Settings = async () => {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/login");
+  }
+
   return (
     <div className="flex flex-col gap-4">
       <h1 className="sticky top-0 z-10 flex items-center justify-between border-b bg-background/50 p-6 text-4xl backdrop-blur-lg">
@@ -14,7 +23,11 @@ const Settings = () => {
             Add or update your information
           </p>
         </div>
-      <ProfileForm />
+        <ProfilePicture
+          profileUrl={session.user?.image!}
+          name={session?.user?.name!}
+        />
+        <ProfileForm user={session.user} />
       </div>
     </div>
   );

--- a/src/components/ProfilePicture.tsx
+++ b/src/components/ProfilePicture.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import Image from "next/image";
+
+type Props = {
+  profileUrl: string;
+  name: string;
+};
+
+const ProfilePicture = ({ profileUrl, name }: Props) => {
+  return (
+    <div className="flex flex-col">
+      <p className="text-lg text-white">Profile Picture</p>
+      <div className="flex h-fit flex-col items-start justify-start">
+        <Image
+          src={profileUrl}
+          alt={`${name} profile picture`}
+          width={200}
+          height={200}
+          className="rounded-md"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ProfilePicture;

--- a/src/components/forms/ProfileForm.tsx
+++ b/src/components/forms/ProfileForm.tsx
@@ -16,16 +16,21 @@ import {
 import { Input } from "@/components/ui/input";
 import { EditUserProfileSchema } from "@/lib/types";
 import { Loader2 } from "lucide-react";
+import { User } from "next-auth";
 
-const ProfileForm = () => {
+type Props = {
+  user: Pick<User, "name" | "email">;
+};
+
+const ProfileForm = ({ user }: Props) => {
   const [isLoading, setIsLoading] = useState(false);
 
   const form = useForm<z.infer<typeof EditUserProfileSchema>>({
     mode: "onChange",
     resolver: zodResolver(EditUserProfileSchema),
     defaultValues: {
-      email: "",
-      name: "",
+      email: user.email || "",
+      name: user.name || "",
     },
   });
 


### PR DESCRIPTION
This pull request introduces several changes to enhance the user profile settings page by adding profile picture functionality and improving authentication handling. The most important changes include adding a new `ProfilePicture` component, updating the `ProfileForm` component to accept user data as props, and modifying the settings page to include authentication checks and display the user's profile picture.

Enhancements to user profile settings:

* [`src/app/(main)/(pages)/settings/page.tsx`](diffhunk://#diff-f34e6cf493fbf74e427da794770e60147bb4f19be1c01d1d600b3bbb3dcfc456R2-L4): Added authentication check to redirect unauthenticated users to the login page and included the `ProfilePicture` component to display the user's profile picture. [[1]](diffhunk://#diff-f34e6cf493fbf74e427da794770e60147bb4f19be1c01d1d600b3bbb3dcfc456R2-L4) [[2]](diffhunk://#diff-f34e6cf493fbf74e427da794770e60147bb4f19be1c01d1d600b3bbb3dcfc456L17-R30)

New components:

* [`src/components/ProfilePicture.tsx`](diffhunk://#diff-ae720200ef38e302a6aa7100605827f2e226e223e76529786d8ef6de17b26f9dR1-R26): Created a new `ProfilePicture` component to display the user's profile picture using the `next/image` component.

Updates to existing components:

* [`src/components/forms/ProfileForm.tsx`](diffhunk://#diff-b41be2a4e4dd974c65cef518b4889b0a9af5eda16a701acfe4e65ab4d613a134R19-R33): Updated the `ProfileForm` component to accept user data as props and initialize form fields with the user's name and email.

Configuration changes:

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bR5-R13): Added configuration for loading remote images from `lh3.googleusercontent.com` to support user profile pictures.