### PR TITLE
Complete Connections Provider

### DIFF
--- a/src/app/(main)/(pages)/workflows/editor/[workflowId]/page.tsx
+++ b/src/app/(main)/(pages)/workflows/editor/[workflowId]/page.tsx
@@ -1,3 +1,4 @@
+import { ConnectionProvider } from "@/providers/ConnectionsProvider";
 import EditorProvider from "@/providers/EditorProvider";
 import React from "react";
 
@@ -13,7 +14,9 @@ const page = async ({ params }: Props) => {
   return (
     <div className="h-full">
       <EditorProvider>
-        <div></div>
+        <ConnectionProvider>
+          <></>
+        </ConnectionProvider>
       </EditorProvider>
     </div>
   );

--- a/src/providers/ConnectionsProvider.tsx
+++ b/src/providers/ConnectionsProvider.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import React, { createContext, useContext, useState } from "react";
+
+export type ConnectionProviderProps = {
+  discordNode: {
+    webhookURL: string;
+    content: string;
+    webhookName: string;
+    guildName: string;
+  };
+  setDiscordNode: React.Dispatch<React.SetStateAction<any>>;
+  googleNode: {}[];
+  setGoogleNode: React.Dispatch<React.SetStateAction<any>>;
+  notionNode: {
+    accessToken: string;
+    databaseId: string;
+    workspaceName: string;
+    content: "";
+  };
+  workflowTemplate: {
+    discord?: string;
+    notion?: string;
+    slack?: string;
+  };
+  setNotionNode: React.Dispatch<React.SetStateAction<any>>;
+  slackNode: {
+    appId: string;
+    authedUserId: string;
+    authedUserToken: string;
+    slackAccessToken: string;
+    botUserId: string;
+    teamId: string;
+    teamName: string;
+    content: string;
+  };
+  setSlackNode: React.Dispatch<React.SetStateAction<any>>;
+  setWorkFlowTemplate: React.Dispatch<
+    React.SetStateAction<{
+      discord?: string;
+      notion?: string;
+      slack?: string;
+    }>
+  >;
+  isLoading: boolean;
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+type ConnectionWithChildProps = {
+  children: React.ReactNode;
+};
+
+const InitialValues: ConnectionProviderProps = {
+  discordNode: {
+    webhookURL: "",
+    content: "",
+    webhookName: "",
+    guildName: "",
+  },
+  googleNode: [],
+  notionNode: {
+    accessToken: "",
+    databaseId: "",
+    workspaceName: "",
+    content: "",
+  },
+  workflowTemplate: {
+    discord: "",
+    notion: "",
+    slack: "",
+  },
+  slackNode: {
+    appId: "",
+    authedUserId: "",
+    authedUserToken: "",
+    slackAccessToken: "",
+    botUserId: "",
+    teamId: "",
+    teamName: "",
+    content: "",
+  },
+  isLoading: false,
+  setGoogleNode: () => undefined,
+  setDiscordNode: () => undefined,
+  setNotionNode: () => undefined,
+  setSlackNode: () => undefined,
+  setIsLoading: () => undefined,
+  setWorkFlowTemplate: () => undefined,
+};
+
+const ConnectionsContext = createContext(InitialValues);
+const { Provider } = ConnectionsContext;
+
+export const ConnectionProvider = ({ children }: ConnectionWithChildProps) => {
+  const [discordNode, setDiscordNode] = useState(InitialValues.discordNode);
+  const [googleNode, setGoogleNode] = useState(InitialValues.googleNode);
+  const [notionNode, setNotionNode] = useState(InitialValues.notionNode);
+  const [slackNode, setSlackNode] = useState(InitialValues.slackNode);
+  const [isLoading, setIsLoading] = useState(InitialValues.isLoading);
+  const [workflowTemplate, setWorkFlowTemplate] = useState(
+    InitialValues.workflowTemplate
+  );
+
+  const values = {
+    discordNode,
+    setDiscordNode,
+    googleNode,
+    setGoogleNode,
+    notionNode,
+    setNotionNode,
+    slackNode,
+    setSlackNode,
+    isLoading,
+    setIsLoading,
+    workflowTemplate,
+    setWorkFlowTemplate,
+  };
+
+  return <Provider value={values}>{children}</Provider>;
+};
+
+export const useNodeConnections = () => {
+  const nodeConnection = useContext(ConnectionsContext);
+  return { nodeConnection };
+};


### PR DESCRIPTION
This pull request introduces a new `ConnectionProvider` to manage various node connections within the application. The most important changes include importing and utilizing the `ConnectionProvider` in the workflow editor page and defining the `ConnectionProvider` with its context and initial values.

### Addition of `ConnectionProvider`:

* `src/app/(main)/(pages)/workflows/editor/[workflowId]/page.tsx`: Imported `ConnectionProvider` and wrapped it around the existing `EditorProvider` to manage node connections. ([src/app/(main)/(pages)/workflows/editor/[workflowId]/page.tsxR1](diffhunk://#diff-e248c7c739536e663b6497522184bc517a4e3fec2ac885ed724bc8ac9b7f123cR1), [src/app/(main)/(pages)/workflows/editor/[workflowId]/page.tsxL16-R19](diffhunk://#diff-e248c7c739536e663b6497522184bc517a4e3fec2ac885ed724bc8ac9b7f123cL16-R19))

### Definition of `ConnectionProvider`:

* [`src/providers/ConnectionsProvider.tsx`](diffhunk://#diff-bd8e9ce2a8e9576b8492c0ea67a50070b0ba24150f1eac88290e8915fda6e054R1-R125): Created `ConnectionProvider` with context, initial values, and state management for various nodes such as Discord, Google, Notion, and Slack. This includes the context setup, initial state values, and custom hooks for accessing the context.