### PR TITLE
Add User Data Fetching, Discord Webhook Schema Update, and Notion Integration

### DIFF
--- a/src/app/(main)/(pages)/connections/_actions/discord-connection.ts
+++ b/src/app/(main)/(pages)/connections/_actions/discord-connection.ts
@@ -1,0 +1,136 @@
+"use server";
+
+import { db } from "@/db/index";
+import { auth } from "../../../../../../auth";
+import { eq } from "drizzle-orm";
+import { discordWebhook, connections } from "@/db/schema";
+
+export const onDiscordConnect = async (
+  channel_id: string,
+  webhook_id: string,
+  webhook_name: string,
+  webhook_url: string,
+  id: string,
+  guild_name: string,
+  guild_id: string
+) => {
+  //check if webhook id params set
+  if (webhook_id) {
+    //check if webhook exists in database with userID
+    const webhook = await db.query.discordWebhook.findFirst({
+      where: eq(discordWebhook.userId, id),
+      with: {
+        connections: true,
+      },
+    });
+
+    //if webhook does not exists for current user
+    if (!webhook) {
+      //create new webhook
+      await db.transaction(async (tx) => {
+        //strep 1: create discordWebhook record
+        const newWebHook = await tx
+          .insert(discordWebhook)
+          .values({
+            userId: id,
+            webhookId: webhook_id,
+            channelId: channel_id,
+            guildId: guild_id,
+            name: webhook_name,
+            url: webhook_url,
+            guildName: guild_name,
+          })
+          .returning(); //returns newly created webhook
+
+        //step 2: create the related connections record
+        await tx.insert(connections).values({
+          userId: id,
+          type: "Discord",
+          discordWebhookId: newWebHook[0].id, // use the ID of newly craeated webhook
+        });
+      });
+    }
+
+    //if webhook exists return check for duplicate
+    if (webhook) {
+      //check if webhhok existst for target channel id
+      const webhook_channel = await db.query.discordWebhook.findFirst({
+        where: eq(discordWebhook.channelId, channel_id),
+        with: {
+          connections: true,
+        },
+      });
+
+      //if no webhook for channel then create new webhook
+      if (!webhook_channel) {
+        await db.transaction(async (tx) => {
+          //strep 1: create discordWebhook record
+          const newWebHook = await tx
+            .insert(discordWebhook)
+            .values({
+              userId: id,
+              webhookId: webhook_id,
+              channelId: channel_id,
+              guildId: guild_id,
+              name: webhook_name,
+              url: webhook_url,
+              guildName: guild_name,
+            })
+            .returning(); //returns newly created webhook
+
+          //step 2: create the related connections record
+          await tx.insert(connections).values({
+            userId: id,
+            type: "Discord",
+            discordWebhookId: newWebHook[0].id, // use the ID of newly craeated webhook
+          });
+        });
+      }
+    }
+  }
+};
+
+export const getDiscordConnectionUrl = async () => {
+  const session = await auth();
+
+  if (!session || !session.user) {
+    return undefined; //if there's no session or user
+  }
+
+  const user = session.user;
+
+  //ensuring user.id is defined and is a string
+  if (typeof user.id !== "string") {
+    return undefined;
+  }
+
+  if (user) {
+    const webhook = await db.query.discordWebhook.findFirst({
+      where: eq(discordWebhook.userId, user.id),
+    });
+
+    return webhook;
+  }
+};
+
+export const postContentToWebHook = async (content: string, url: string) => {
+  if (content != "") {
+    const postReqeust = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(content),
+    });
+
+    const posted = await postReqeust.json();
+
+    if (posted) {
+      return { message: "success" };
+    }
+
+    return { message: "failed request" };
+  }
+
+  return { message: "String empty" };
+};

--- a/src/app/(main)/(pages)/connections/_actions/get-user.tsx
+++ b/src/app/(main)/(pages)/connections/_actions/get-user.tsx
@@ -1,0 +1,16 @@
+"use server";
+
+import { db } from "@/db/index";
+import { users } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+export const getUserData = async (id: string) => {
+  const user_info = await db.query.users.findFirst({
+    where: eq(users.id, id),
+    with: {
+      connections: true,
+    },
+  });
+
+  return user_info;
+};

--- a/src/app/(main)/(pages)/connections/_actions/notion-connection.ts
+++ b/src/app/(main)/(pages)/connections/_actions/notion-connection.ts
@@ -1,0 +1,116 @@
+"use server";
+
+import { db } from "@/db";
+import { auth } from "../../../../../../auth";
+import { Client } from "@notionhq/client";
+import { eq } from "drizzle-orm";
+import { connections, notion } from "@/db/schema";
+
+export const onNotionConnect = async (
+  access_token: string,
+  workspace_id: string,
+  workspace_icon: string,
+  workspace_name: string,
+  database_id: string,
+  id: string
+) => {
+  "user server";
+  if (access_token) {
+    //check if notion is connected
+    const notion_connected = await db.query.notion.findFirst({
+      where: eq(notion.accessToken, access_token),
+      with: {
+        connections: true,
+      },
+    });
+
+    if (!notion_connected) {
+      //create connection
+      await db.transaction(async (tx) => {
+        await tx
+          .insert(notion)
+          .values({
+            userId: id,
+            workspaceIcon: workspace_icon,
+            accessToken: access_token,
+            workspaceId: workspace_id,
+            workspaceName: workspace_name,
+            databaseId: database_id,
+          })
+          .returning();
+
+        await tx.insert(connections).values({
+          userId: id,
+          type: "Notion",
+        });
+      });
+    }
+  }
+};
+
+export const getNotionConnection = async () => {
+  const session = await auth();
+
+  if (!session || !session.user) {
+    return undefined; //if there's no session or user
+  }
+
+  const user = session.user;
+
+  //ensuring user.id is defined and is a string
+  if (typeof user.id !== "string") {
+    return undefined;
+  }
+
+  if (user) {
+    const connection = await db.query.notion.findFirst({
+      where: eq(notion.userId, user.id),
+    });
+
+    if (connection) {
+      return connection;
+    }
+  }
+};
+
+export const getNotionDatabase = async (
+  databaseId: string,
+  accessToken: string
+) => {
+  const notion = new Client({
+    auth: accessToken,
+  });
+
+  const response = await notion.databases.retrieve({ database_id: databaseId });
+  return response;
+};
+
+export const onCreateNewPageInDatabase = async (
+  databaseId: string,
+  accessToken: string,
+  content: string
+) => {
+  const notion = new Client({
+    auth: accessToken,
+  });
+
+  const response = await notion.pages.create({
+    parent: {
+      type: "database_id",
+      database_id: databaseId,
+    },
+    properties: {
+      name: [
+        {
+          text: {
+            content: content,
+          },
+        },
+      ],
+    },
+  });
+
+  if (response) {
+    return response;
+  }
+};

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -97,12 +97,16 @@ export const discordWebhook = pgTable("discordWebhook", {
   userId: text("userId"),
 });
 
-export const discordWebhookRelations = relations(discordWebhook, ({ one }) => ({
-  user: one(users, {
-    fields: [discordWebhook.userId],
-    references: [users.id],
-  }),
-}));
+export const discordWebhookRelations = relations(
+  discordWebhook,
+  ({ one, many }) => ({
+    user: one(users, {
+      fields: [discordWebhook.userId],
+      references: [users.id],
+    }),
+    connections: many(connections),
+  })
+);
 
 export const slack = pgTable("slack", {
   id: text("id")


### PR DESCRIPTION
This pull request introduces new functionalities for managing Discord and Notion connections, as well as retrieving user data. It includes changes to multiple files to handle database interactions and API requests for these services.

### New functionalities for Discord and Notion connections:

* [`src/app/(main)/(pages)/connections/_actions/discord-connection.ts`](diffhunk://#diff-423ef4fc756954437ea7fd858d1a784221a324c9fcb3f11ba286aaba3993da16R1-R136): Added functions to handle Discord webhook connections, including creating and checking for existing webhooks, and posting content to webhooks.
* [`src/app/(main)/(pages)/connections/_actions/notion-connection.ts`](diffhunk://#diff-a9c7eefcaf22bffd9db8e79fac733de991b7ba65734ba824ad0e9efc24c62320R1-R116): Added functions to manage Notion connections, retrieve Notion databases, and create new pages in Notion databases.

### User data retrieval:

* [`src/app/(main)/(pages)/connections/_actions/get-user.tsx`](diffhunk://#diff-328394820b57fc2f12114fff29a53141582a2114f507430c2ac809e74445ba2cR1-R16): Added a function to retrieve user data from the database, including their connections.

### Database schema updates:

* [`src/db/schema.ts`](diffhunk://#diff-4bccf0a85960664570150bcf86a66e64e825b88f02fe19c2e323e96f65e2d55fL100-R109): Updated the `discordWebhookRelations` to include a many-to-one relationship with the `connections` table.