### PR TITLE
fix: callback api route for slack & discord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env.local
-
+.env
 # vercel
 .vercel
 

--- a/src/app/api/auth/callback/discord/route.ts
+++ b/src/app/api/auth/callback/discord/route.ts
@@ -3,48 +3,56 @@ import { NextResponse, NextRequest } from "next/server";
 import url from "url";
 
 export async function GET(req: NextRequest) {
-  const code = req.nextUrl.searchParams.get("code");
-  if (code) {
-    const data = new url.URLSearchParams();
-    data.append("client_id", process.env.DISCORD_CLIENT_ID!);
-    data.append("client_secret", process.env.DISCORD_CLIENT_SECRET!);
-    data.append("grant_type", "authorization_code");
-    data.append(
-      "redirect_uri",
-      "https://localhost:3000/api/auth/callback/discord"
-    );
-    data.append("code", code.toString());
+  try {
+    console.log(req.url);
+    const code = req.nextUrl.searchParams.get("code");
+    
+    if (code) {
+      const data = new url.URLSearchParams();
+      data.append("client_id", process.env.DISCORD_CLIENT_ID!);
+      data.append("client_secret", process.env.DISCORD_CLIENT_SECRET!);
+      data.append("grant_type", "authorization_code");
+      data.append(
+        "redirect_uri",
+        "http://localhost:3000/api/auth/callback/discord"
+      );
+      data.append("code", code.toString());
 
-    const output = await axios.post(
-      "https://discord.com/api/oauth2/token",
-      data,
-      {
+      const output = await fetch("https://discord.com/api/oauth2/token", {
+        method: "POST",
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
         },
+        body: new URLSearchParams(data),
+      });
+
+      if (output.ok) {
+        const response = await output.json();
+        const access = response.access_token;
+        const UserGuilds: any = await axios.get(
+          `https://discord.com/api/users/@me/guilds`,
+          {
+            headers: {
+              Authorization: `Bearer ${access}`,
+            },
+          }
+        );
+
+        const UserGuild = UserGuilds.data.filter(
+          (guild: any) => guild.id == response.webhook.guild_id
+        );
+
+        return NextResponse.redirect(
+          `http://localhost:3000/connections?webhook_id=${response.webhook.id}&webhook_url=${response.webhook.url}&webhook_name=${response.webhook.name}&guild_id=${response.webhook.guild_id}&guild_name=${UserGuild[0].name}&channel_id=${response.webhook.channel_id}`
+        );
       }
-    );
-
-    if (output.data) {
-      const access = output.data.access_token;
-      const UserGuilds: any = await axios.get(
-        `https://discord.com/api/users/@me/guilds`,
-        {
-          headers: {
-            Authorization: `Bearer ${access}`,
-          },
-        }
-      );
-
-      const UserGuild = UserGuilds.data.filter(
-        (guild: any) => guild.id == output.data.webhook.guild_id
-      );
-
-      return NextResponse.redirect(
-        `https://localhost:3000/connections?webhook_id=${output.data.webhook.id}&webhook_url=${output.data.webhook.url}&webhook_name=${output.data.webhook.name}&guild_id=${output.data.webhook.guild_id}&guild_name=${UserGuild[0].name}&channel_id=${output.data.webhook.channel_id}`
-      );
     }
-
     return NextResponse.redirect("https://localhost:3000/connections");
+  } catch (error) {
+    console.error("Failed discord callback route: ", error);
+    return NextResponse.json(
+      { error: "Failed discord callback route" },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/auth/callback/slack/route.ts
+++ b/src/app/api/auth/callback/slack/route.ts
@@ -42,11 +42,11 @@ export async function GET(req: NextRequest) {
 
       // Handle the successful OAuth flow and redirect the user
       return NextResponse.redirect(
-        `https://localhost:3000/connections?app_id=${appId}&authed_user_id=${userId}&authed_user_token=${userToken}&slack_access_token=${accessToken}&bot_user_id=${botUserId}&team_id=${teamId}&team_name=${teamName}`
+        `http://localhost:3000/connections?app_id=${appId}&authed_user_id=${userId}&authed_user_token=${userToken}&slack_access_token=${accessToken}&bot_user_id=${botUserId}&team_id=${teamId}&team_name=${teamName}`
       );
     }
   } catch (error) {
-    console.error(error);
+    console.error("Slack callback api error:: ", error);
     return new NextResponse("Internal Server Error", { status: 500 });
   }
 }


### PR DESCRIPTION
- fix api route not redirecting to the `/connections` route due to typo
- update logic inside the api routes
- fix typo that are causing the issue